### PR TITLE
fix: use queue module for Empty exception

### DIFF
--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -163,7 +163,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
                     )
                 )
 
-            except Queue.Empty:
+            except queue.Empty:
                 continue
             except Exception:
                 self.channel, self.connection = None, None


### PR DESCRIPTION
A recent change made `message_worker` handle Empty queue exceptions.
Unfortunatley, the change accidently scoped the Empty exception as part
of the Queue class, rather than the queue module. It's possible that
older versions of python worked with this. However, for sure python 3.9+
does not.

Change the code to use the module: `queue.Empty`.