### PR TITLE
More queue improvements

### DIFF
--- a/python_logging_rabbitmq/compat.py
+++ b/python_logging_rabbitmq/compat.py
@@ -5,9 +5,11 @@ import sys
 if sys.version_info[0] == 2:
     text_type = unicode
     from Queue import Queue as Queue
+    from Queue import Empty
 else:
     text_type = str
     from queue import Queue as Queue
+    from queue import Empty
 
 try:
     import ujson as json  # noqa: F401

--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -7,6 +7,7 @@ from copy import copy
 import pika
 from pika import credentials
 
+from .compat import Empty
 from .compat import Queue
 from .filters import FieldFilter
 from .formatters import JSONFormatter
@@ -163,7 +164,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
                     )
                 )
 
-            except queue.Empty:
+            except Empty:
                 continue
             except Exception:
                 self.channel, self.connection = None, None
@@ -210,6 +211,12 @@ class RabbitMQHandlerOneWay(logging.Handler):
         except Exception:
             self.channel, self.connection = None, None
             self.handleError(record)
+
+    def queue_depth(self):
+        """
+        How many log messages the handler is waiting to send.
+        """
+        return self.queue.qsize()
 
     def close(self):
         """

--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -151,18 +151,21 @@ class RabbitMQHandlerOneWay(logging.Handler):
             try:
                 record, routing_key = self.queue.get(block=True, timeout=10)
 
-                if not self.connection or self.connection.is_closed or not self.channel or self.channel.is_closed:
-                    self.open_connection()
+                try:
+                    if not self.connection or self.connection.is_closed or not self.channel or self.channel.is_closed:
+                        self.open_connection()
 
-                res = self.channel.basic_publish(
-                    exchange=self.exchange,
-                    routing_key=routing_key,
-                    body=record,
-                    properties=pika.BasicProperties(
-                        delivery_mode=2,
-                        headers=self.message_headers
+                    res = self.channel.basic_publish(
+                        exchange=self.exchange,
+                        routing_key=routing_key,
+                        body=record,
+                        properties=pika.BasicProperties(
+                            delivery_mode=2,
+                            headers=self.message_headers
+                        )
                     )
-                )
+                finally:
+                    self.queue.task_done()
 
             except Empty:
                 continue
@@ -173,7 +176,6 @@ class RabbitMQHandlerOneWay(logging.Handler):
                 if self.stopping.is_set():
                     self.stopped.set()
                     break
-                self.queue.task_done()
                 if self.close_after_emit:
                     self.close_connection()
         self.stopped.set()


### PR DESCRIPTION
The PR improves three things:
 
 - It fixes a crash which happens when the queue is empty *despite* the earlier fix which caught the proper exception. It was failing because task_done can only be called if a task was dequeued. If an exception occurs before one is, that function throws.
 - It properly uses the local compatibility layer to catch the appropriate Empty exception
 - It adds a queue_depth function which can help to discover processes having issues pushing into rabbitmq