### PR TITLE
fix: return no messages queued if no queue

### DIFF
--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -218,6 +218,9 @@ class RabbitMQHandlerOneWay(logging.Handler):
         """
         How many log messages the handler is waiting to send.
         """
+        if self.queue is None:
+            return 0
+
         return self.queue.qsize()
 
     def close(self):


### PR DESCRIPTION
The queue in the RabbitMQHandlerOneWay is deleted on shutdown. The
queue_depth() method would raise an exception failure in that case, when
it should really just be returning 0. Fix it to return 0.