### PR TITLE
fix: add callback for instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ These are the configuration allowed:
 | message_headers       | A dictionary of headers to be published with the message.                                                                                | None                                  |
 | record_fields         | A set of attributes that should be preserved from the record object.                                                                     | None                                  |
 | exclude_record_fields | A set of attributes that should be ignored from the record object.                                                                       | None                                  |
+| send_callback         | A function taking a single int invoked with the number of succesfully sent messages. Useful for instrumentation.                         | None                                  |
+| send_fail_callback    | A function taking a single int invoked with the number of failed messages. Useful for instrumentation.                                   | None                                  |
 
 
 ### Examples


### PR DESCRIPTION
This adds callbacks to allow for instrumenting the handler. This can
help with detecting misconfiguration or stability issues. The callbacks
are invoked when a message is sent or if a message fails to send.

An alternative would have been to use locking to implement a counter
which could be synchronously read.  This is more complicated than simply
calling out to a function and allowing it to make the decision on how to
lock if at all. Further, the callbacks are easier to use with frameworks
like prometheus.