### PR TITLE
fix: use JoinableQueue if gevent

### DIFF
--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -10,7 +10,7 @@ from pika import credentials
 try:
     from gevent import monkey
     if monkey.is_module_patched("_thread"):
-        from gevent.queue import Queue
+        from gevent.queue import JoinableQueue as Queue
         from gevent.queue import Empty
     else:
         from .compat import Empty


### PR DESCRIPTION
The gevent Queue is not api-compatible with the queue.Queue. In particular, it's missing the join/task_done workflow. Instead, it implements that in the JoinableQueue. Because of this, the worker raised an exception when trying the mark the record as done when using the gevent. This in turn lead to the worker always sending the message twice: once initially, and then again in the "retry" loop.

Fix the problem by importing the JoinableQueue instead of the default gevent Queue.